### PR TITLE
改为UDP套接字，并且添加有效IP作为广播判断依据

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -10,7 +10,6 @@ import (
 
 // siliconvn.dscloud.me
 var (
-	serverStartUp bool     = false
 	clientStartUp bool     = false
 	tunPrt        *tun.TUN = nil
 )
@@ -24,8 +23,7 @@ func Start(k *conf.Key) {
 	log.SetLevel(level)
 	if k.Server {
 		log.Infof("正在开启服务端")
-		serverStartUp = server.StartServer(k)
-		if !serverStartUp {
+		if !server.StartUDPServer(k) {
 			log.Infof("启动服务器失败，请退出程序")
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -23,13 +23,13 @@ func init() {
 	flag.IntVar(&key.DevMask, "devmask", 24, "设备掩码")
 	flag.StringVar(&key.DevIP, "devip", "192.168.55.24", "设备IP地址")
 	flag.BoolVar(&key.Client, "client", true, "是否开启客户端")
-	flag.StringVar(&key.ClientIP, "clientip", "127.0.0.1", "客户端使用的地址")
-	flag.IntVar(&key.ClientPort, "clientport", 11451, "客户端使用的端口")
+	flag.StringVar(&key.ClientIP, "clientip", "0.0.0.0", "客户端使用的地址")
+	flag.IntVar(&key.ClientPort, "clientport", 11455, "客户端使用的端口")
 	flag.BoolVar(&key.Server, "server", false, "是否开启服务端")
-	flag.StringVar(&key.ServerIP, "serverip", "127.0.0.1", "服务端监听地址")
-	flag.IntVar(&key.ServerPort, "serverport", 11455, "服务端监听端口")
+	flag.StringVar(&key.ServerIP, "serverip", "0.0.0.0", "服务端监听地址")
+	flag.IntVar(&key.ServerPort, "serverport", 11451, "服务端监听端口")
 	flag.StringVar(&key.RemoteServerIP, "remoteip", "127.0.0.1", "客户端的服务端地址")
-	flag.IntVar(&key.RemoteServerPort, "remoteport", 11455, "客户端的服务端端口")
+	flag.IntVar(&key.RemoteServerPort, "remoteport", 11451, "客户端的服务端端口")
 	flag.Parse()
 }
 func main() {

--- a/packet/IPPacket.go
+++ b/packet/IPPacket.go
@@ -14,7 +14,7 @@ func UnpackIPPacket(data []byte) IPPacket {
 	bs := data[0]
 	pro.Version = bs >> 4
 	pro.HeadLen = int(bs << 4 >> 4)
-	pro.TotalLen = int(data[2])*256 + int(data[3])
+	pro.TotalLen = int(data[2])<<8 + int(data[3])
 	pro.SRC = data[12:16]
 	pro.DST = data[16:20]
 	pro.Protocol = data[9]

--- a/packet/TransPacket.go
+++ b/packet/TransPacket.go
@@ -5,22 +5,27 @@ import (
 	"strings"
 )
 
-var MaxLen = 1414
+var MaxLen = 1418
 
 type TransPacket struct {
 	TransType uint8 //1byte 包类型
-	//6：客户端发送给服务器的数据
-	//1：服务器发送给客户端的数据
-	//2：客户端发送给服务器的路由登录
-	//3：服务器回复登录成功
-	//4: 服务器回复 你申请的IP已经被占用
-	//5：客户端发送给服务器的心跳
-	Len  int    //2byte 数据长度
-	SRC  []byte //4byte 设备IP
-	DST  []byte //4byte 目的地址 从IP数据的DST解析上来的
-	Bro  uint8  //1byte 是否是广播
-	Pro  uint8  //1byte 数据包协议
-	Mask uint8  //1byte 掩码
+	//200：客户端发送给服务器的数据
+	//201：服务器发送给客户端的数据
+	//202：客户端发送给服务器的路由登录
+	//203：服务器回复登录成功
+	//204: 服务器回复 你申请的IP已经被占用
+	//205：客户端发送给服务器的心跳
+	Len   int    //2byte 数据长度
+	SRC   []byte //4byte 设备IP
+	DST   []byte //4byte 目的地址 从IP数据的DST解析上来的
+	EffIP []byte //4byte 有效位IP
+	Bro   uint8  //1byte 是否是广播
+	//1：广播数据
+	//2：非广播数据
+	Pro  uint8 //1byte 数据包协议
+	Mask uint8 //1byte 掩码
+
+	//以上 8项 18byte
 	Data []byte //最大1400byte长度 数据
 }
 
@@ -31,6 +36,7 @@ func PackPacket(data TransPacket) []byte {
 	packet = append(packet, IntToTwo(data.Len)...)
 	packet = append(packet, data.SRC...)
 	packet = append(packet, data.DST...)
+	packet = append(packet, data.EffIP...)
 	packet = append(packet, data.Bro)
 	packet = append(packet, data.Pro)
 	packet = append(packet, data.Mask)
@@ -44,10 +50,11 @@ func UnpackPacket(data []byte) TransPacket {
 	pac.Len = TwoToInt(data[1:3])
 	pac.SRC = data[3:7]
 	pac.DST = data[7:11]
-	pac.Bro = data[11]
-	pac.Pro = data[12]
-	pac.Mask = data[13]
-	pac.Data = data[14:]
+	pac.EffIP = data[11:15]
+	pac.Bro = data[15]
+	pac.Pro = data[16]
+	pac.Mask = data[17]
+	pac.Data = data[18:]
 	return pac
 }
 func PackIP(ip string) []byte {

--- a/sock/client/client.go
+++ b/sock/client/client.go
@@ -12,9 +12,9 @@ import (
 
 var (
 	emptyData                        = []byte("1")
-	client_defaultMask               = uint8(24)
+	client_defaultMask               = 24
 	client_defauleDevIP              = ""
-	client_TCP          *net.TCPConn = nil
+	client_UDP          *net.UDPConn = nil
 )
 
 func StartClient(t *tun.TUN, k *conf.Key) bool {
@@ -25,109 +25,106 @@ func StartClient(t *tun.TUN, k *conf.Key) bool {
 	}
 	k.RemoteServerIP = ns[0]
 	client_defauleDevIP = k.DevIP
-	client_defaultMask = uint8(k.DevMask)
-	TCPLocal := net.TCPAddr{IP: net.ParseIP(k.ClientIP), Port: k.ClientPort}
-	TCPRemote := net.TCPAddr{IP: net.ParseIP(k.RemoteServerIP), Port: k.RemoteServerPort}
+	client_defaultMask = k.DevMask
+	UDPLocal := net.UDPAddr{IP: net.ParseIP(k.ClientIP), Port: k.ClientPort}
+	UDPRemote := net.UDPAddr{IP: net.ParseIP(k.RemoteServerIP), Port: k.RemoteServerPort}
 
-	ok, tcp, err := clientTryTCP(&TCPLocal, &TCPRemote)
+	ok, udp, err := clientTryUDP(&UDPLocal, &UDPRemote)
 	if !ok {
-		log.Errorf("客户端-尝试TCP连接服务器失败:%v", err)
+		log.Errorf("客户端-尝试连接服务器失败:%v", err)
 		return false
 	}
-	client_TCP = tcp
+	client_UDP = udp
 	go clientWrite(t)
-	go clientTCPReadHandle(t)
+	go clientRead(t)
 	return true
 }
-func clientTryTCP(local, remote *net.TCPAddr) (bool, *net.TCPConn, error) {
-	log.Infof("客户端正在尝试TCP连接%v", remote)
-	tcp, err := net.DialTCP("tcp", local, remote)
+func clientTryUDP(local, remote *net.UDPAddr) (bool, *net.UDPConn, error) {
+	log.Infof("客户端正在尝试连接%v", remote)
+	udp, err := net.DialUDP("udp", local, remote)
 	if err != nil {
-		log.Errorf("客户端尝试TCP连接失败:%v", err)
+		log.Errorf("客户端尝试连接失败(1):%v", err)
 		return false, nil, err
 	}
+	_, effIP := IsBroadcast(packet.PackIP(client_defauleDevIP), client_defaultMask)
 	login := packet.TransPacket{
-		TransType: 2,
+		TransType: 202,
 		Len:       1,
 		SRC:       packet.PackIP(client_defauleDevIP),
 		DST:       packet.PackIP("127.0.0.1"),
+		EffIP:     effIP,
 		Bro:       2,
 		Pro:       20,
-		Mask:      client_defaultMask,
+		Mask:      uint8(client_defaultMask),
 		Data:      emptyData,
 	}
-	_, err = tcp.Write(packet.PackPacket(login))
+	_, err = udp.Write(packet.PackPacket(login))
 	if err != nil {
-		log.Errorf("客户端尝试TCP连接失败:%v", err)
+		log.Errorf("客户端尝试连接失败(2):%v", err)
 		return false, nil, err
 	}
-	retData := make([]byte, 14)
-	_, err = tcp.Read(retData)
+	data := make([]byte, 1500)
+	len, err := udp.Read(data)
 	if err != nil {
-		log.Errorf("客户端尝试TCP连接失败:%v", err)
+		log.Errorf("客户端尝试连接失败(3):%v", err)
 		return false, nil, err
 	}
-	retData = append(retData, byte(1))
-	packet := packet.UnpackPacket(retData)
-	log.Debugf("客户端尝试TCP 收到数据：%v", packet)
-	if packet.TransType == 3 {
-		log.Infof("客户端尝试TCP连接成功")
-		data := make([]byte, packet.Len)
-		tcp.Read(data)
-		return true, tcp, nil
+	effData := data[0:len]
+	pak := packet.UnpackPacket(effData)
+	log.Debugf("服务器返回数据：%v", pak)
+	if pak.TransType == 203 {
+		log.Infof("客户连接服务器成功")
+		return true, udp, nil
 	}
-	if packet.TransType == 4 {
-		log.Infof("该IP已被占用,请尝试其他IP")
-	}
-	return false, nil, err
+	return false, nil, nil
 }
 
-func clientTCPWriteHandle(data []byte, len int, ipinfo packet.IPPacket) bool {
-	log.Debugf("客户端-TCP数据长度:%v", len)
+func clientWriteHandle(data []byte, len int, ipinfo packet.IPPacket) bool {
+	log.Debugf("客户端-数据长度:%v", len)
 	if len > 1400 {
 		len = 1400
 	}
 	pac := packet.TransPacket{
-		TransType: 6,
+		TransType: 200,
 		Len:       len,
-		SRC:       packet.PackIP(client_defauleDevIP),
+		SRC:       ipinfo.SRC,
 		DST:       ipinfo.DST,
-		Bro:       2,
 		Pro:       ipinfo.Protocol,
-		Mask:      client_defaultMask,
+		Mask:      uint8(client_defaultMask),
 		Data:      data[0:len],
 	}
-	if IsBroadcast(ipinfo.DST, client_defaultMask) {
-		pac.Bro = 1
-	}
-	log.Debugf("客户端-TCP数据:%v", pac)
-	_, err := client_TCP.Write(packet.PackPacket(pac))
+	bro, effIP := IsBroadcast(ipinfo.DST, client_defaultMask)
+	pac.Bro = bro
+	pac.EffIP = effIP
+	log.Debugf("客户端-数据:%v", pac)
+	_, err := client_UDP.Write(packet.PackPacket(pac))
 	if err != nil {
-		log.Errorf("客户端-TCP发数据给服务器错误(连接或许已经关闭):%v", err)
+		log.Errorf("客户端-发数据给服务器错误(连接或许已经关闭):%v", err)
 		return false
 	}
 	return true
 }
-func clientTCPReadHandle(t *tun.TUN) {
+func clientRead(t *tun.TUN) {
 	for {
-		receive := make([]byte, 14)
-		_, err := client_TCP.Read(receive)
-		log.Debugf("客户端-TCP读取到数据(头部):%v", receive)
+		receive := make([]byte, 1500)
+		len, err := client_UDP.Read(receive)
 		if err != nil {
-			log.Errorf("客户端-TCP读取数据错误,请关闭程序:%v", err)
+			log.Errorf("客户端-读取数据错误,请关闭程序:%v", err)
 			return
 		}
-		receive = append(receive, byte(1))
-		receivePac := packet.UnpackPacket(receive)
-		buf := make([]byte, receivePac.Len)
-		_, err = client_TCP.Read(buf)
-		if err != nil {
-			log.Errorf("客户端-TCP读取数据错误,请关闭程序:%v", err)
-			return
+		effReceive := receive[0:len]
+		receivePac := packet.UnpackPacket(effReceive)
+		buf := receivePac.Data
+		if receivePac.TransType == 201 {
+			_, err = t.Write(buf)
+			if err != nil {
+				log.Errorf("客户端-写入设备失败,请关闭程序:%v", err)
+				return
+			}
 		}
-		_, err = t.Write(buf)
-		if err != nil {
-			log.Errorf("客户端-TCP写入设备失败,请关闭程序:%v", err)
+		if receivePac.TransType == 204 {
+			client_UDP.Close()
+			log.Infof("该IP被另一人占用,请使用其他IP")
 			return
 		}
 	}
@@ -145,48 +142,61 @@ func clientWrite(t *tun.TUN) {
 		if pac.Version != 4 {
 			continue
 		}
-		if !clientTCPWriteHandle(data, n, pac) {
-			log.Infof("客户端写入失败")
+		if !clientWriteHandle(data, n, pac) {
+			log.Infof("客户端-写入失败")
 			return
 		}
 	}
 }
 func heartBeat() {
 	hb := packet.TransPacket{
-		TransType: 5,
+		TransType: 205,
 		Len:       1,
 		SRC:       packet.PackIP(client_defauleDevIP),
 		DST:       packet.PackIP("127.0.0.1"),
+		EffIP:     packet.PackIP("127.0.0.1"),
 		Bro:       2,
 		Pro:       20,
-		Mask:      client_defaultMask,
+		Mask:      uint8(client_defaultMask),
 		Data:      emptyData,
 	}
 	hbByte := packet.PackPacket(hb)
 	for {
 		time.Sleep(time.Second * 10)
-		_, err := client_TCP.Write(hbByte)
+		_, err := client_UDP.Write(hbByte)
 		if err != nil {
 			log.Errorf("客户端-发送心跳数据出错:%v", err)
 			return
 		}
 	}
 }
-func IsBroadcast(dst net.IP, mask uint8) bool {
+func IsBroadcast(dst net.IP, mask int) (uint8, net.IP) {
 	//判断是否是广播信息
 	result := mask / 8
 	remain := mask % 8
 	if result > 4 {
-		return false
+		return 2, dst
 	}
+	effIP := make([]byte, 4)
 	bronum := 0
-	for i := result; i < 4; i++ {
+	for i := 0; i < 4; i++ {
+		if i < result {
+			//全广播阻拦
+			//向目的地址网段广播
+			effIP[i] = dst[i]
+		}
 		if i == result {
+			effIP[i] = dst[i] >> (8 - remain) << (8 - remain)
 			bronum = int(dst[i] << remain >> remain)
-		} else {
+		}
+		if i > result {
+			effIP[i] = 0
 			bronum = bronum*256 + int(dst[i])
 		}
 	}
 	//2的n次方减1
-	return bronum == int(math.Pow(2, float64(32-mask)))-1
+	if bronum == int(math.Pow(2, float64(32-mask)))-1 {
+		return 1, effIP
+	}
+	return 2, effIP
 }

--- a/sock/sockRoute.go
+++ b/sock/sockRoute.go
@@ -5,9 +5,15 @@ import (
 )
 
 // 服务器：SRC->remote
-type ServerTCP struct {
+type TCPTab struct {
 	Addr net.Addr //远端真实地址
 	SRC  string   //远端虚拟ip
 	Mask uint8    //远端虚拟ip掩码
 	Dial net.Conn
+}
+type UDPTab struct {
+	Remote net.Addr //远端真实地址
+	SRC    string   //远端虚拟ip
+	EffIP  string   //掩码有效位IP
+	Mask   uint8    //远端虚拟ip掩码
 }


### PR DESCRIPTION
目前已知bug：同一个IP:端口 创建两个以上IP之后，无法通过UDP判断该IP:端口是否重复。在其他IP:端口 申请其中一个时，会导致之前的IP:端口 断开。